### PR TITLE
Chore/remove add description of

### DIFF
--- a/packages/finder_matcher_gen/lib/src/builders/matcher_class_builder.dart
+++ b/packages/finder_matcher_gen/lib/src/builders/matcher_class_builder.dart
@@ -100,7 +100,7 @@ abstract class BaseMatcherMethodsCodeBuilder {
   /// Responsible for writing describe() into [StringBuffer]
   void writeDescribeMethod(StringBuffer stringBuffer) {
     stringBuffer.writeln(
-      """return description.add('matches $expectCount $className widget').addDescriptionOf(this);""",
+      """return description.add('matches $expectCount $className widget');""",
     );
   }
 

--- a/packages/finder_matcher_gen/lib/src/utils/validation_code_helper.dart
+++ b/packages/finder_matcher_gen/lib/src/utils/validation_code_helper.dart
@@ -25,7 +25,7 @@ String getMatcherConditionCodeFromExtract(
       '''matchState['${extractCode(extract)}-expected'] = ${extract.defaultValue == null ? '$extractValue' : '${extract.defaultValue}'};\n''',
     )
     ..writeln('''if(matchState['${extractCode(extract)}-found'] == null) {''')
-    ..writeln('''matchState['${extractCode(extract)}-found'] = {};''')
+    ..writeln('''matchState['${extractCode(extract)}-found'] = <dynamic>{};''')
     ..writeln('}\n')
     ..writeln(
       '''matchState['${extractCode(extract)}-found'].add(${extractCode(extract)});''',


### PR DESCRIPTION
- Appending addDescriptionOf(this) to the matcher `description` caused overflow error.
- When tracking the mismatched declaration found, {} was interpreted as map instead of set