### PR TITLE
Resolved #36

### DIFF
--- a/packages/example/test/widget_test.finders.dart
+++ b/packages/example/test/widget_test.finders.dart
@@ -38,7 +38,7 @@ class _MyHomePageMatchFinder<T, R> extends MatchFinder {
     if (candidiate.widget is MyHomePage) {
       final widget = candidiate.widget as MyHomePage;
 
-      return widget.title == 'love-title' &&
+      return widget.title == 'love-leads' &&
           widget.generic == _genericValue &&
           listEquals(widget.incrementCounter(), _incrementCounterValue);
     }

--- a/packages/example/test/widget_test.matchers.dart
+++ b/packages/example/test/widget_test.matchers.dart
@@ -56,10 +56,10 @@ class _MyHomePageMatcher<T, R> extends Matcher {
 
           var expectedDeclarationCount = 0;
 
-          if (widget.title == 'love-title') {
+          if (widget.title == 'love-leads') {
             expectedDeclarationCount++;
           } else {
-            matchState['widget.title-expected'] = 'love-title';
+            matchState['widget.title-expected'] = 'love-leads';
 
             if (matchState['widget.title-found'] == null) {
               matchState['widget.title-found'] = <dynamic>{};

--- a/packages/finder_matcher_gen/lib/src/class_visitor.dart
+++ b/packages/finder_matcher_gen/lib/src/class_visitor.dart
@@ -40,6 +40,15 @@ class ClassVisitor extends SimpleElementVisitor<void> {
       ///to this package standard
       checkBadTypeByFieldElement(element);
 
+      final importUri = isNotPartOfDartCore(element.type)
+          ? element.type.element?.source?.uri
+          : null;
+
+      if (importUri != null) {
+        _classExtract = _classExtract.copyWithImport(
+          import: importUri.toString(),
+        );
+      }
       _classExtract = _classExtract.copyWithDeclarationExtract(
         extract: DeclarationExtract(
           name: element.name,
@@ -78,6 +87,16 @@ class ClassVisitor extends SimpleElementVisitor<void> {
             name: '${element.name}Value',
             type: element.returnType.dartTypeStr,
           ),
+        );
+      }
+
+      final importUri = isNotPartOfDartCore(element.type)
+          ? element.returnType.element?.source?.uri
+          : null;
+
+      if (importUri != null) {
+        _classExtract = _classExtract.copyWithImport(
+          import: importUri.toString(),
         );
       }
 

--- a/packages/finder_matcher_gen/lib/src/generators/base_annotation_generator.dart
+++ b/packages/finder_matcher_gen/lib/src/generators/base_annotation_generator.dart
@@ -148,6 +148,10 @@ abstract class BaseAnnotaionGenerator extends GeneratorForAnnotation<Match> {
     if (_requiresFoundation(classExtract)) {
       _importsStringBuffer.writeln("import 'package:flutter/foundation.dart';");
     }
+
+    for (final import in classExtract.imports ?? {}) {
+      _writeImport("import '$import';");
+    }
   }
 
   bool _requiresFoundation(ClassElementExtract classExtract) {
@@ -155,6 +159,12 @@ abstract class BaseAnnotaionGenerator extends GeneratorForAnnotation<Match> {
             ?.where((element) => element.fieldEquality != null)
             .isNotEmpty ??
         false;
+  }
+
+  void _writeImport(String import) {
+    if (doesNotContainImport(import)) {
+      _importsStringBuffer.writeln(import);
+    }
   }
 
   /// Return true if [importToWrite] does not exist in import string buffer

--- a/packages/finder_matcher_gen/lib/src/generators/finder_generator.dart
+++ b/packages/finder_matcher_gen/lib/src/generators/finder_generator.dart
@@ -27,6 +27,7 @@ class FinderGenerator extends BaseAnnotaionGenerator {
     super.writeClassToBuffer(extract, classStringBuffer);
   }
 
+
   @override
   String prefix(ClassElementExtract extract) => 'find';
 

--- a/packages/finder_matcher_gen/lib/src/models/class_extract_model.dart
+++ b/packages/finder_matcher_gen/lib/src/models/class_extract_model.dart
@@ -13,6 +13,7 @@ class ClassElementExtract extends Equatable {
     this.declarations,
     this.genericParam = '',
     this.constructorFields,
+    this.imports,
   });
 
   final String? className;
@@ -20,6 +21,7 @@ class ClassElementExtract extends Equatable {
   final String genericParam;
   final List<DeclarationExtract>? declarations;
   final Set<ConstructorFieldModel>? constructorFields;
+  final Set<String>? imports;
 
   String? get generatedClassName => className == null ? null : '_$className';
 
@@ -29,6 +31,7 @@ class ClassElementExtract extends Equatable {
     String? genericParam,
     List<DeclarationExtract>? declarations,
     Set<ConstructorFieldModel>? constructorFields,
+    Set<String>? imports,
   }) {
     return ClassElementExtract(
       className: className ?? this.className,
@@ -36,6 +39,7 @@ class ClassElementExtract extends Equatable {
       genericParam: genericParam ?? this.genericParam,
       declarations: declarations ?? this.declarations,
       constructorFields: constructorFields ?? this.constructorFields,
+      imports: imports ?? this.imports,
     );
   }
 
@@ -65,14 +69,28 @@ class ClassElementExtract extends Equatable {
     return copyWith(constructorFields: fieldList);
   }
 
-  @override
-  String toString() {
-    return '''ClassElementExtract(className: $className, classUri: $classUri, isGeneric: $genericParam methods: $declarations, constructorFields: $constructorFields)''';
+  ClassElementExtract copyWithImport({
+    required String import,
+  }) {
+    final importList = (imports ?? {})..add(import);
+
+    return copyWith(imports: importList);
   }
 
   @override
-  List<Object?> get props =>
-      [className, classUri, genericParam, declarations, constructorFields];
+  String toString() {
+    return '''ClassElementExtract(className: $className, classUri: $classUri, isGeneric: $genericParam methods: $declarations, constructorFields: $constructorFields, imports: $imports)''';
+  }
+
+  @override
+  List<Object?> get props => [
+        className,
+        classUri,
+        genericParam,
+        declarations,
+        constructorFields,
+        imports
+      ];
 }
 
 class DeclarationExtract extends Equatable {

--- a/packages/finder_matcher_gen/lib/src/utils/element_checker.dart
+++ b/packages/finder_matcher_gen/lib/src/utils/element_checker.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// Throws an exception when class element does not comform to generation
@@ -47,6 +48,23 @@ void checkBadTypeByMethodElement(MethodElement element) {
 void checkBadTypeByFieldElement(FieldElement element) {
   checkElementNotPrivate(element);
 }
+
+/// Checks if this [DartType] is not core library
+bool isNotPartOfDartCore(DartType dartType) =>
+    !dartType.isDartCoreBool &&
+    !dartType.isDartCoreDouble &&
+    !dartType.isDartCoreEnum &&
+    !dartType.isDartCoreInt &&
+    !dartType.isDartCoreIterable &&
+    !dartType.isDartCoreList &&
+    !dartType.isDartCoreMap &&
+    !dartType.isDartCoreNull &&
+    !dartType.isDartCoreNum &&
+    !dartType.isDartCoreObject &&
+    !dartType.isDartCoreRecord &&
+    !dartType.isDartCoreSet &&
+    !dartType.isDartCoreString &&
+    !dartType.isDartCoreSymbol;
 
 /// Throws an exception when [Element] is private
 void checkElementNotPrivate(Element element) {


### PR DESCRIPTION
If I have a widget named `MyWidget` with a field with my own defined class `MyModel` in a different file `models.dart`.

By marking this field with @MatchDeclaration, the generated matcher/finder file generates without an import of `NyModel`. This PR fixes that.

## Status

**READY**

## Description

Updated `ClassElementExtract` to have a `List<String> imports` field.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
