### PR TITLE
fixed getter annotation lint and generation

### DIFF
--- a/packages/finder_matcher_gen/bin/util/extensions.dart
+++ b/packages/finder_matcher_gen/bin/util/extensions.dart
@@ -27,8 +27,10 @@ extension ElementExt on Element {
       .hasAnnotationOf(this, throwOnUnresolved: false);
 
   String? get declarationType {
-    if (kind == ElementKind.GETTER || kind == ElementKind.METHOD) {
+    if (kind == ElementKind.METHOD) {
       return (this as MethodElement).returnType.toString();
+    } else if (kind == ElementKind.GETTER) {
+      return (this as PropertyAccessorElement).returnType.toString();
     } else if (kind == ElementKind.FIELD) {
       return (this as FieldElement).type.toString();
     }

--- a/packages/finder_matcher_gen/bin/util/lints.dart
+++ b/packages/finder_matcher_gen/bin/util/lints.dart
@@ -136,8 +136,15 @@ class InvalidMatchDeclaration extends AnalysisErrorLint {
 
     if ((element.kind == ElementKind.FIELD) &&
         (element as FieldElement).isStatic) return InvalidType.static;
-    if (element.kind == ElementKind.METHOD ||
-        element.kind == ElementKind.GETTER) {
+    if (element.kind == ElementKind.GETTER) {
+      final accessorElement = element as PropertyAccessorElement;
+
+      if (accessorElement.isStatic) return InvalidType.static;
+
+      if (accessorElement.returnType.isVoid) return InvalidType.voidReturnType;
+    }
+
+    if (element.kind == ElementKind.METHOD) {
       final methodElement = element as MethodElement;
 
       if (methodElement.isStatic) return InvalidType.static;

--- a/packages/finder_matcher_gen/lib/src/generators/base_annotation_generator.dart
+++ b/packages/finder_matcher_gen/lib/src/generators/base_annotation_generator.dart
@@ -64,7 +64,8 @@ abstract class BaseAnnotaionGenerator extends GeneratorForAnnotation<Match> {
 
       final elements = List<Element>.from([])
         ..addAll(classElement.fields)
-        ..addAll(classElement.methods);
+        ..addAll(classElement.methods)
+        ..addAll(classElement.accessors);
 
       if (elements.hasAtleastOneMatchDeclarationAnnotation) {
         _buildClassWithDeclarationValidation(classElement, generic);

--- a/packages/finder_matcher_gen/lib/src/utils/element_checker.dart
+++ b/packages/finder_matcher_gen/lib/src/utils/element_checker.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:finder_matcher_gen/src/class_visitor.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// Throws an exception when class element does not comform to generation
@@ -33,14 +34,14 @@ void checkBadTypeByClassElement(
 
 /// Throws an exception when [MethodElement] does not conform to
 /// method generation specification
-void checkBadTypeByMethodElement(MethodElement element) {
+void checkBadTypeByMethodElement(MethodGetterElementWrapper element) {
   if (element.parameters.isNotEmpty) {
     throwException(
       'Unsupported: annotated method should have no parameter',
-      element: element,
+      element: element.element,
     );
   }
-  checkElementNotPrivate(element);
+  checkElementNotPrivate(element.element);
 }
 
 /// Throws an exception when [FieldElement] type does not conform to


### PR DESCRIPTION
These are the fixes contained in this PR:

1.  Unexpected default type lint error doesn't work when a getter is annotated with `@MatchDeclaration`  and a different default value is passed.
2. Generated Matcher code does not utilise getters for checks.
3. Default value for getters annotated with `@MatchDeclaration`not utilised.

## Status

**READY**

## Description

In `ClassVisitor` classes I override `visitPropertyAccessorElement(PropertyAccessorElement element)` to visit getter elements.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
